### PR TITLE
feat(dagir): add read‑only external DAG view concepts and helpers

### DIFF
--- a/include/dagir/ro_dag_view.hpp
+++ b/include/dagir/ro_dag_view.hpp
@@ -3,45 +3,91 @@
 //
 // DagIR - Read-only external DAG view concepts and helpers
 // A lightweight interface for traversing foreign DAGs without copying.
+//
+// © DagIR Contributors. All rights reserved.
 
 #include <concepts>
 #include <cstdint>
 #include <ranges>
+#include <string>
 #include <type_traits>
 #include <utility>
 
 namespace dagir {
 
+/**
+ * @file ro_dag_view.hpp
+ * @brief Core concepts and small utilities for creating read-only external DAG views.
+ *
+ * The contracts in this header let algorithms (e.g., topological order, post‑order
+ * folds, IR builders) traverse *foreign* DAGs without copying or owning the data.
+ * Adapters implement these concepts on top of backends like TeDDy, CUDD, or
+ * any domain DAG (build graphs, expression DAGs, workflow DAGs, etc.).
+ */
+
 //-----------------------------
 // 1) Core element concepts
 //-----------------------------
 
-/// Opaque, cheap handle to a node in a foreign DAG.
-/// Identity must be stable for the lifetime of a traversal.
+/**
+ * @brief Opaque, cheap handle to a node in a foreign DAG.
+ *
+ * @tparam H Handle type provided by an adapter.
+ *
+ * @details
+ * A type models ::dagir::NodeHandle when:
+ *  - It is @c std::copyable
+ *  - It exposes @c stable_key() returning a @c std::uint64_t suitable for memoization
+ *  - It exposes @c debug_address() returning a @c const void* (may be @c nullptr)
+ *  - It supports equality/inequality with identity semantics
+ *
+ * @note
+ *  - If a backend has complemented edges or phases (e.g., CUDD), incorporate those
+ *    semantics into the handle identity (and therefore its @c stable_key()).
+ */
 template <class H>
 concept NodeHandle =
     std::copyable<H> &&
     requires (const H& h) {
-        // 64-bit stable key usable for memo tables, maps, sets, etc.
         { h.stable_key() }    -> std::convertible_to<std::uint64_t>;
-        // Optional debug hook (may return nullptr)
         { h.debug_address() } -> std::convertible_to<const void*>;
-        // Identity equality (same logical node; phase should be included by the handle if relevant)
         { h == h }            -> std::same_as<bool>;
         { h != h }            -> std::same_as<bool>;
     };
 
-/// A lightweight edge reference yielding a child handle.
-/// Labels/weights are optional and can be added by adapters if needed.
+/**
+ * @brief Lightweight, read-only edge reference that yields a child handle.
+ *
+ * @tparam E Edge reference type provided by an adapter.
+ * @tparam H The adapter's node handle type.
+ *
+ * @details
+ * A type models ::dagir::EdgeRef when it provides:
+ *  - @c target() -> @c H
+ *
+ * Optional:
+ *  - @c label() returning any type (weight, annotation, etc.). Not required
+ *    by the concept; algorithms/policies can SFINAE on availability.
+ */
 template <class E, class H>
 concept EdgeRef =
     requires (const E& e) {
         { e.target() } -> std::convertible_to<H>;
         // Optional:
-        // { e.label() } -> /* anything */;
+        // { e.label() } -> /* any type */;
     };
 
-// Ranges-v3-like compatibility: accept either value-type or reference-type edge models.
+/**
+ * @brief Range of child edges for a node.
+ *
+ * @tparam R Range type returned by @c children(handle).
+ * @tparam H Adapter's node handle type.
+ *
+ * @details
+ * Models ::dagir::ChildrenRange if @c R is an @c input_range whose
+ * value_type *or* reference_type satisfies ::dagir::EdgeRef.
+ * This permits views that yield either edge values or edge references.
+ */
 template <class R, class H>
 concept ChildrenRange =
     std::ranges::input_range<R> &&
@@ -52,30 +98,42 @@ concept ChildrenRange =
 // 2) Read-only External DAG View concept
 //-----------------------------------------------
 
-/// A read-only view over a foreign DAG (no ownership, no mutation).
-/// Requirements deliberately small: handle type + children() + roots().
+/**
+ * @brief Read-only, non-owning view over a foreign DAG.
+ *
+ * @tparam G Adapter/view type.
+ *
+ * @details
+ * A type models ::dagir::ReadOnlyDagView when:
+ *  - It defines @c using handle = ... ; and that type models ::dagir::NodeHandle
+ *  - It provides @c children(handle) returning a ::dagir::ChildrenRange of edges
+ *  - It provides @c roots() returning an @c input_range of @c handle values
+ *
+ * Optional:
+ *  - @c start_guard(handle) returning an RAII guard object (e.g., to pin nodes,
+ *    disable reordering, or otherwise enforce traversal safety). Adapters that
+ *    do not require any guarding may return ::dagir::NoopGuard.
+ */
 template <class G>
 concept ReadOnlyDagView =
     requires (const G& g, typename G::handle h) {
-        // Handle type
         typename G::handle; requires NodeHandle<typename G::handle>;
-
-        // Outgoing edges of a node (read-only). Range of edge refs yielding handles.
         { g.children(h) } -> ChildrenRange<typename G::handle>;
-
-        // Roots of the subgraph represented by this view (can be empty if caller supplies roots).
-        { g.roots() } -> std::ranges::input_range;
-
-        // Optional no-op guard for backends that need pinning/critical sections.
-        // Adapters can provide: auto guard = g.start_guard(h); (RAII type)
+        { g.roots() }     -> std::ranges::input_range;
+        // Optional: g.start_guard(h)
     };
 
 //-----------------------------------------------
 // 3) Lightweight adapter utilities (optional)
 //-----------------------------------------------
 
-/// A default, no-op guard for adapters that don't need pinning/reordering control.
-/// Adapters can `using guard_type = NoopGuard;` and return it from start_guard().
+/**
+ * @brief No-op RAII guard for adapters that do not require pinning/reordering locks.
+ *
+ * @details
+ * Adapters can @c using guard_type = ::dagir::NoopGuard and implement
+ * @c start_guard(handle) returning a @c NoopGuard to satisfy uniform call sites.
+ */
 struct NoopGuard {
     NoopGuard() = default;
     ~NoopGuard() = default;
@@ -85,8 +143,17 @@ struct NoopGuard {
     NoopGuard& operator=(NoopGuard&&) = default;
 };
 
-/// A tiny helper to check at compile-time that a type models ReadOnlyDagView.
-/// Usage: static_assert(dagir::models_read_only_view<MyView>());
+/**
+ * @brief Compile-time probe: returns @c true if @p V models ::dagir::ReadOnlyDagView.
+ *
+ * @tparam V Candidate view type.
+ * @return constexpr @c bool
+ *
+ * @usage
+ * @code
+ * static_assert(dagir::models_read_only_view<MyView>(), "MyView must model ReadOnlyDagView");
+ * @endcode
+ */
 template <class V>
 consteval bool models_read_only_view() {
     if constexpr (ReadOnlyDagView<V>) return true;
@@ -96,29 +163,57 @@ consteval bool models_read_only_view() {
 //-----------------------------------------------
 // 4) Example: minimal edge wrapper (for adapters)
 //-----------------------------------------------
-// Adapters can reuse this if they just need a simple E{H} edge type.
 
+/**
+ * @brief Trivial edge wrapper that stores a child handle by value.
+ *
+ * @tparam H Handle type that models ::dagir::NodeHandle.
+ *
+ * @details
+ * Adapters may reuse this when they do not need custom edge labels/weights.
+ */
 template <NodeHandle H>
 struct BasicEdge {
-    H to;
+    H to;                                      ///< Child handle
+    /// @brief Returns the child handle.
     constexpr const H& target() const noexcept { return to; }
 };
 
 //-----------------------------------------------
 // 5) Example: policy hooks (labels, attributes)
 //-----------------------------------------------
-// These are *not* part of the core concept, but serve as extension points
-// that renderers/IR builders can depend on without forcing any backend shape.
 
-/// Node labeler policy callable: F(const View&, handle) -> std::string
+/**
+ * @brief Concept for a node labeling policy callable.
+ *
+ * @tparam F Callable type.
+ * @tparam View A type that models ::dagir::ReadOnlyDagView.
+ *
+ * @details
+ * A type models ::dagir::NodeLabeler when an lvalue of @c F is invocable as:
+ *  - @c f(view, handle) and returns a @c std::string
+ *
+ * This lets renderers/IR-builders fetch labels without coupling to adapter internals.
+ */
 template <class F, class View>
 concept NodeLabeler =
     requires (const F& f, const View& v, const typename View::handle& h) {
         { f(v, h) } -> std::convertible_to<std::string>;
     };
 
-/// Edge attribute policy callable (optional):
-/// F(const View&, parent_handle, child_handle) -> attribute struct/string/map
+/**
+ * @brief Concept for an edge attribute policy callable.
+ *
+ * @tparam F Callable type.
+ * @tparam View A type that models ::dagir::ReadOnlyDagView.
+ *
+ * @details
+ * A type models ::dagir::EdgeAttributor when an lvalue of @c F is invocable as:
+ *  - @c f(view, parent_handle, child_handle)
+ *
+ * The return type is unconstrained (string, struct, map, etc.) and is left to the
+ * renderer/IR builder to interpret. Edge attribution is optional.
+ */
 template <class F, class View>
 concept EdgeAttributor =
     requires (const F& f, const View& v,


### PR DESCRIPTION
Introduce a minimal, header‑only interface for traversing external DAGs without copying. The new header defines core concepts and utilities that algorithms (topo order, post‑order fold, IR builder) can depend on.

What’s included
- concept dagir::NodeHandle: opaque, copyable handle with stable_key() and optional debug_address()
- concept dagir::EdgeRef: lightweight edge reference exposing target()
- concept dagir::ChildrenRange: input_range of EdgeRef (by value or ref)
- concept dagir::ReadOnlyDagView: handle type + children(handle) + roots()
- dagir::NoopGuard: optional RAII for backends that don’t need pinning
- dagir::models_read_only_view<V>() helper for static_assert checks
- dagir::BasicEdge<H>: tiny reusable edge wrapper template
- Optional policy hooks: NodeLabeler, EdgeAttributor concepts

Why
- Establishes a stable, backend‑agnostic contract for external DAG adapters (e.g., TeDDy, CUDD, expression DAGs) without imposing ownership/mutation.
- Keeps algorithms portable and zero‑copy while allowing adapter‑specific lifetimes and safety guards (e.g., reordering locks in CUDD).

Notes
- No breaking changes; this is additive.
- Adapters may optionally expose start_guard() returning NoopGuard (or a real RAII guard for backends that need it).

Suggested file path
- include/dagir/ro_dag_view.hpp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a lightweight read-only DAG view interface for traversing external directed acyclic graphs.
  * Introduced type-safe contracts for node handles, edge references, and children ranges to improve adapter correctness.
  * Added a minimal edge wrapper and compile-time check to validate read-only backends.
  * Enabled customizable node labeling and edge attribution hooks.
  * Added optional no-op synchronization guard support for adapters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->