### PR TITLE
Add unit tests for ReadOnlyDagView and utilities

### DIFF
--- a/tests/test_ro_dag_view.cpp 
+++ b/tests/test_ro_dag_view.cpp 
@@ -3,10 +3,10 @@
  * @brief Unit tests for DagIR ReadOnlyDagView concept and related utilities.
  *
  * @details
- * This test verifies:
- *  - A mock adapter correctly models ::dagir::ReadOnlyDagView.
- *  - Bounds checking prevents out-of-range access for children() and roots().
- *  - Concepts and helper utilities behave as expected.
+ * This test suite validates:
+ *  - Compliance of mock types with DagIR concepts (NodeHandle, EdgeRef, ReadOnlyDagView).
+ *  - Safe bounds checking for children() and roots() to prevent undefined behavior.
+ *  - Utility helpers like BasicEdge and models_read_only_view().
  *
  * @copyright
  * © DagIR Contributors. All rights reserved.
@@ -20,38 +20,58 @@
 #include <cstdint>
 
 /**
- * @brief Mock handle type for testing NodeHandle concept.
+ * @class MockHandle
+ * @brief Minimal handle type for concept testing.
+ *
+ * @details
+ * Implements:
+ *  - stable_key() for identity
+ *  - debug_address() for diagnostics
+ *  - Equality operators
  */
 struct MockHandle {
     std::uint64_t id{};
+    /// @brief Returns a stable key for memoization.
     constexpr std::uint64_t stable_key() const noexcept { return id; }
+    /// @brief Returns a debug address (pointer to self).
     constexpr const void* debug_address() const noexcept { return this; }
     friend constexpr bool operator==(MockHandle a, MockHandle b) noexcept { return a.id == b.id; }
     friend constexpr bool operator!=(MockHandle a, MockHandle b) noexcept { return !(a == b); }
 };
 
 /**
- * @brief Mock edge type for testing EdgeRef concept.
+ * @class MockEdge
+ * @brief Minimal edge wrapper exposing target().
  */
 struct MockEdge {
     MockHandle child{};
+    /// @brief Returns the child handle.
     constexpr MockHandle target() const noexcept { return child; }
 };
 
 /**
- * @brief Mock DAG view that satisfies ReadOnlyDagView.
+ * @class MockDagView
+ * @brief Mock adapter modeling ReadOnlyDagView for tests.
  *
- * Adds bounds checking for children() and roots().
+ * @details
+ * Provides:
+ *  - children(handle): range of edges, empty if out-of-bounds.
+ *  - roots(): range of handles, empty if roots_ is empty.
  */
 class MockDagView {
 public:
     using handle = MockHandle;
 
+    /// @brief Constructs a mock DAG view.
     explicit MockDagView(std::vector<handle> roots,
                          std::vector<std::vector<handle>> adjacency)
         : roots_(std::move(roots)), adj_(std::move(adjacency)) {}
 
-    /// @brief Returns range of children for a given handle, empty if out-of-bounds.
+    /**
+     * @brief Returns range of children for a given handle.
+     * @param h Node handle.
+     * @return Range of edges or empty range if index is invalid.
+     */
     auto children(handle h) const {
         const size_t idx = static_cast<size_t>(h.id);
         if (idx >= adj_.size()) {
@@ -82,7 +102,10 @@ public:
         return Range{ &adj_[idx] };
     }
 
-    /// @brief Returns range of roots, empty if roots_ is empty.
+    /**
+     * @brief Returns range of roots.
+     * @return Range of handles or empty range if roots_ is empty.
+     */
     auto roots() const {
         if (roots_.empty()) {
             struct EmptyRange {
@@ -121,9 +144,12 @@ private:
 };
 
 // -----------------------------
-// Tests
+// Unit Tests
 // -----------------------------
 
+/**
+ * @test Verify NodeHandle concept compliance.
+ */
 TEST_CASE("MockHandle satisfies NodeHandle concept", "[concepts]") {
     STATIC_REQUIRE(dagir::NodeHandle<MockHandle>);
     MockHandle h{42};
@@ -131,6 +157,9 @@ TEST_CASE("MockHandle satisfies NodeHandle concept", "[concepts]") {
     REQUIRE(h.debug_address() == &h);
 }
 
+/**
+ * @test Verify EdgeRef concept compliance.
+ */
 TEST_CASE("MockEdge satisfies EdgeRef concept", "[concepts]") {
     STATIC_REQUIRE(dagir::EdgeRef<MockEdge, MockHandle>);
     MockHandle h{7};
@@ -138,6 +167,9 @@ TEST_CASE("MockEdge satisfies EdgeRef concept", "[concepts]") {
     REQUIRE(e.target().stable_key() == 7);
 }
 
+/**
+ * @test Verify ReadOnlyDagView concept compliance and helper.
+ */
 TEST_CASE("MockDagView satisfies ReadOnlyDagView concept", "[concepts]") {
     STATIC_REQUIRE(dagir::ReadOnlyDagView<MockDagView>);
     STATIC_REQUIRE(dagir::models_read_only_view<MockDagView>());
@@ -157,12 +189,18 @@ TEST_CASE("MockDagView satisfies ReadOnlyDagView concept", "[concepts]") {
     REQUIRE(emptyChildren.begin() == emptyChildren.end());
 }
 
+/**
+ * @test Verify empty roots returns empty range.
+ */
 TEST_CASE("Empty roots returns empty range", "[bounds]") {
     MockDagView emptyView({}, {});
     auto emptyRoots = emptyView.roots();
     REQUIRE(emptyRoots.begin() == emptyRoots.end());
 }
 
+/**
+ * @test Verify BasicEdge utility works with NodeHandle.
+ */
 TEST_CASE("BasicEdge wrapper returns correct target", "[utility]") {
     dagir::BasicEdge<MockHandle> edge{ MockHandle{99} };
     REQUIRE(edge.target().stable_key() == 99);


### PR DESCRIPTION
This pull request adds a new unit test file for the `ReadOnlyDagView` concept and related utilities. The tests verify that mock types and helpers correctly implement and recognize the required concepts for DAG views, node handles, and edge references.

**Testing and Concept Verification:**

* Adds `test_ro_dag_view.cpp`, which:
  - Implements mock types (`MockHandle`, `MockEdge`, `MockDagView`) to test the `NodeHandle`, `EdgeRef`, and `ReadOnlyDagView` concepts.
  - Verifies at compile time and runtime that the mock types satisfy their respective concepts using static and runtime assertions.
  - Tests the `models_read_only_view` helper function for correct behavior.
  - Includes a test for the `BasicEdge` utility with a mock handle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for DAG view validation and boundary condition handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->