### PR TITLE
Update test source file gathering in CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,10 +102,10 @@ if(DAGIR_BUILD_TESTS)
   endif()
 
   # Gather test sources (portable glob; users can add more files).
-  file(GLOB DAGIR_TEST_SOURCES
-    "${CMAKE_CURRENT_SOURCE_DIR}/tests/*.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/tests/*_test.cpp"
-  )
+  file(GLOB DAGIR_TEST_SOURCES CONFIGURE_DEPENDS
+    "${PROJECT_SOURCE_DIR}/tests/*.cpp"
+    "${PROJECT_SOURCE_DIR}/tests/*_test.cpp")
+  message(STATUS "DagIR: Collected test sources: ${DAGIR_TEST_SOURCES}")
 
   if(DAGIR_TEST_SOURCES)
     add_executable(dagir_tests ${DAGIR_TEST_SOURCES})


### PR DESCRIPTION
This pull request updates how test sources are collected in the `CMakeLists.txt` file, improving reliability and developer feedback during the build process.

Test source collection improvements:

* The `file(GLOB ...)` command for gathering test sources now uses `CONFIGURE_DEPENDS` to ensure CMake automatically re-detects new or removed test files on subsequent builds, and switches from `CMAKE_CURRENT_SOURCE_DIR` to `PROJECT_SOURCE_DIR` for more consistent path resolution.
* A status message is added to print the list of collected test sources during configuration, making it easier to debug and verify which test files are included.