### PR TITLE
Update test source file gathering in CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,6 @@ if(DAGIR_BUILD_TESTS)
   # Gather test sources (portable glob; users can add more files).
   file(GLOB DAGIR_TEST_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/tests/*.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/tests/*_test.cpp"
   )
 
   if(DAGIR_TEST_SOURCES)


### PR DESCRIPTION
This pull request makes a minor change to the test source file globbing in the `CMakeLists.txt` file. The pattern for including files ending with `_test.cpp` in the test sources has been removed, so only `.cpp` files directly under `tests/` will be included as test sources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined test file discovery configuration in the build system to streamline test compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->