### PR TITLE
Rename test_ro_dag_view.cpp to remove trailing spaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ compile_commands.json
 CTestTestfile.cmake
 _deps
 CMakeUserPresets.json
+/build*/**
 
 # CLion
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can


### PR DESCRIPTION
This pull request refactors the `MockDagView` test helper in `tests/test_ro_dag_view.cpp` to simplify how ranges are returned from the `children` and `roots` methods. It also updates the Catch2 include to use only the required macros. These changes make the test code easier to read and maintain by replacing custom iterator types and range structs with standard `std::vector` return values.

Test infrastructure simplification:

* Simplified the `children` and `roots` methods in the `MockDagView` class to return `std::vector` objects directly instead of custom range/iterator structs, making the code more maintainable and idiomatic.

Test framework update:

* Updated the Catch2 include in `tests/test_ro_dag_view.cpp` to use only `catch_test_macros.hpp` instead of the full framework, reducing unnecessary dependencies in the test file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build directory exclusion patterns in repository configuration.

* **Tests**
  * Updated test framework integration and refactored test utilities for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->