### PR TITLE
Algorithm tests

### DIFF
--- a/include/algorithms.hpp
+++ b/include/algorithms.hpp
@@ -63,7 +63,6 @@ std::vector<typename View::handle> kahn_topological_order(const View& view) {
 
 	for (std::size_t i = 0; i < work.size(); ++i) {
 		H cur = work[i];
-		key_t curk = cur.stable_key();
 		for (auto const &edge_like : view.children(cur)) {
 			H child = extract_child(edge_like);
 			key_t ck = child.stable_key();

--- a/include/dagir/algorithms.hpp
+++ b/include/dagir/algorithms.hpp
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: MIT
+// Forwarding header for algorithms implementation
+#pragma once
+#include "../algorithms.hpp"

--- a/tests/test_algorithm.cpp
+++ b/tests/test_algorithm.cpp
@@ -1,0 +1,73 @@
+/**
+ * @file test_algorithm.cpp
+ * @brief Unit tests for DagIR algorithm utilities.
+ *
+ * @details
+ * This test suite validates:
+ * - Correctness of Kahn's topological sort implementation.
+ * - Proper handling of cycles in the DAG.
+ * - Correctness of postorder folding over the DAG.
+ * - Edge cases and error handling.
+ * 
+ * @copyright
+ * © DagIR Contributors. All rights reserved.
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <catch2/catch_test_macros.hpp>
+#include <dagir/algorithms.hpp>
+
+#include "mock_dag.hpp"
+
+// -----------------------------
+using dagir::kahn_topological_order;
+using dagir::postorder_fold;
+
+TEST_CASE("kahn_topological_order - simple chain", "[algorithms]") {
+	// 0 -> 1 -> 2
+	MockDagView g({MockHandle{0}}, {{MockHandle{1}}, {MockHandle{2}}, {}});
+	auto order = kahn_topological_order(g);
+	REQUIRE(order.size() == 3);
+	// stable_key() returns id
+	REQUIRE(order[0].stable_key() == 0);
+	REQUIRE(order[1].stable_key() == 1);
+	REQUIRE(order[2].stable_key() == 2);
+}
+
+TEST_CASE("kahn_topological_order - multiple roots and branching", "[algorithms]") {
+	// Roots: 0, 1 ; edges: 0 -> 2, 1 -> 2, 2 -> 3
+	MockDagView g({MockHandle{0}, MockHandle{1}}, {{MockHandle{2}}, {MockHandle{2}}, {MockHandle{3}}, {}});
+	auto order = kahn_topological_order(g);
+	REQUIRE(order.size() == 4);
+	// first two elements should be 0 and 1 (order between them unspecified)
+	std::unordered_set<std::uint64_t> first_two = { order[0].stable_key(), order[1].stable_key() };
+	REQUIRE(first_two.count(0));
+	REQUIRE(first_two.count(1));
+	REQUIRE(order[2].stable_key() == 2);
+	REQUIRE(order[3].stable_key() == 3);
+}
+
+TEST_CASE("kahn_topological_order - cycle detection", "[algorithms]") {
+	// 0 -> 1 -> 0 (cycle)
+	MockDagView g({MockHandle{0}}, {{MockHandle{1}}, {MockHandle{0}}});
+	REQUIRE_THROWS_AS(kahn_topological_order(g), std::runtime_error);
+}
+
+TEST_CASE("postorder_fold - sum of child results + node id", "[algorithms]") {
+	// 0 -> 1 -> 2 ; values: use id as base value
+	MockDagView g({MockHandle{0}}, {{MockHandle{1}}, {MockHandle{2}}, {}});
+
+	auto combiner = [](auto const& /*view*/, MockHandle node, std::span<const int> children) -> int {
+		int sum = static_cast<int>(node.stable_key());
+		for (int v : children) sum += v;
+		return sum;
+	};
+
+	auto results = postorder_fold<MockDagView, int>(g, combiner);
+	// node 2: 2
+	REQUIRE(results.at(2) == 2);
+	// node 1: 1 + child(2) = 3
+	REQUIRE(results.at(1) == 3);
+	// node 0: 0 + child(1) = 3
+	REQUIRE(results.at(0) == 3);
+}


### PR DESCRIPTION
This pull request introduces a new test suite for DAG algorithm utilities, adds a forwarding header for algorithms, and makes a minor cleanup in the topological order implementation. The changes improve code organization, test coverage, and maintainability.

**Testing improvements:**

* Added a comprehensive unit test suite in `tests/test_algorithm.cpp` to validate Kahn's topological sort, cycle detection, postorder folding, and edge cases for DAG algorithms. This ensures correctness and robustness of the core utilities.

**Code organization and maintainability:**

* Introduced a forwarding header `dagir/algorithms.hpp` with SPDX license information, re-exporting the main algorithms header for easier and standardized inclusion.

**Code cleanup:**

* Removed an unused variable (`curk`) from the `kahn_topological_order` implementation in `algorithms.hpp`, simplifying the code.