### PR TITLE
mermaid: request default theme to avoid dark-mode colour issues (fix #28)

### DIFF
--- a/include/dagir/render_mermaid.hpp
+++ b/include/dagir/render_mermaid.hpp
@@ -82,6 +82,12 @@ inline std::string escape_mermaid(const std::string& s) {
  * @param graph_name Optional identifier for the graph (used in comments only).
  */
 inline void render_mermaid(std::ostream& os, const ir_graph& g, std::string_view graph_name = "G") {
+  // Ensure consistent appearance on platforms (e.g. GitHub) that may
+  // apply a dark theme to Mermaid renderings. Emit an init directive
+  // to request the default (light) Mermaid theme so node fill/stroke
+  // colours remain visible.
+  os << "%%{ init: {\"theme\": \"default\"} }%%\n";
+
   // Determine direction: prefer graph-level k_rankdir if present
   std::string rankdir = "TB";
   if (g.global_attrs.count(std::string(ir_attrs::k_rankdir)))

--- a/samples/expression_bdd_mermaid/and_ab.md
+++ b/samples/expression_bdd_mermaid/and_ab.md
@@ -1,4 +1,5 @@
 ```mermaid
+%%{ init: {"theme": "default"} }%%
 graph TB
   node000("a")
   node001("b")

--- a/samples/expression_bdd_mermaid/and_chain.md
+++ b/samples/expression_bdd_mermaid/and_chain.md
@@ -1,4 +1,5 @@
 ```mermaid
+%%{ init: {"theme": "default"} }%%
 graph TB
   node000("a")
   node001("b")

--- a/samples/expression_bdd_mermaid/complex.md
+++ b/samples/expression_bdd_mermaid/complex.md
@@ -1,4 +1,5 @@
 ```mermaid
+%%{ init: {"theme": "default"} }%%
 graph TB
   node000("a")
   node001("b")

--- a/samples/expression_bdd_mermaid/deep_all_ops.md
+++ b/samples/expression_bdd_mermaid/deep_all_ops.md
@@ -1,4 +1,5 @@
 ```mermaid
+%%{ init: {"theme": "default"} }%%
 graph TB
   node000("alpha")
   node001("beta")

--- a/samples/expression_bdd_mermaid/mixed_1.md
+++ b/samples/expression_bdd_mermaid/mixed_1.md
@@ -1,4 +1,5 @@
 ```mermaid
+%%{ init: {"theme": "default"} }%%
 graph TB
   node000("a")
   node001("b")

--- a/samples/expression_bdd_mermaid/mixed_2.md
+++ b/samples/expression_bdd_mermaid/mixed_2.md
@@ -1,4 +1,5 @@
 ```mermaid
+%%{ init: {"theme": "default"} }%%
 graph TB
   node000("x")
   node001("y")

--- a/samples/expression_bdd_mermaid/not_and_or.md
+++ b/samples/expression_bdd_mermaid/not_and_or.md
@@ -1,4 +1,5 @@
 ```mermaid
+%%{ init: {"theme": "default"} }%%
 graph TB
   node000("x")
   node001("y")

--- a/samples/expression_bdd_mermaid/not_p.md
+++ b/samples/expression_bdd_mermaid/not_p.md
@@ -1,4 +1,5 @@
 ```mermaid
+%%{ init: {"theme": "default"} }%%
 graph TB
   node000("p")
   node001["1"]

--- a/samples/expression_bdd_mermaid/or_chain.md
+++ b/samples/expression_bdd_mermaid/or_chain.md
@@ -1,4 +1,5 @@
 ```mermaid
+%%{ init: {"theme": "default"} }%%
 graph TB
   node000("p")
   node001("q")

--- a/samples/expression_bdd_mermaid/or_xy.md
+++ b/samples/expression_bdd_mermaid/or_xy.md
@@ -1,4 +1,5 @@
 ```mermaid
+%%{ init: {"theme": "default"} }%%
 graph TB
   node000("x")
   node001("y")

--- a/samples/expression_bdd_mermaid/single_var.md
+++ b/samples/expression_bdd_mermaid/single_var.md
@@ -1,4 +1,5 @@
 ```mermaid
+%%{ init: {"theme": "default"} }%%
 graph TB
   node000("z")
   node001["0"]

--- a/samples/expression_bdd_mermaid/xor_mn.md
+++ b/samples/expression_bdd_mermaid/xor_mn.md
@@ -1,4 +1,5 @@
 ```mermaid
+%%{ init: {"theme": "default"} }%%
 graph TB
   node000("m")
   node001("n")

--- a/samples/expression_tree_mermaid/and_ab.md
+++ b/samples/expression_tree_mermaid/and_ab.md
@@ -1,4 +1,5 @@
 ```mermaid
+%%{ init: {"theme": "default"} }%%
 graph TB
   node000["AND"]
   style node000 fill:lightgreen

--- a/samples/expression_tree_mermaid/and_chain.md
+++ b/samples/expression_tree_mermaid/and_chain.md
@@ -1,4 +1,5 @@
 ```mermaid
+%%{ init: {"theme": "default"} }%%
 graph TB
   node000["AND"]
   style node000 fill:lightgreen

--- a/samples/expression_tree_mermaid/complex.md
+++ b/samples/expression_tree_mermaid/complex.md
@@ -1,4 +1,5 @@
 ```mermaid
+%%{ init: {"theme": "default"} }%%
 graph TB
   node000["OR"]
   style node000 fill:lightcoral

--- a/samples/expression_tree_mermaid/deep_all_ops.md
+++ b/samples/expression_tree_mermaid/deep_all_ops.md
@@ -1,4 +1,5 @@
 ```mermaid
+%%{ init: {"theme": "default"} }%%
 graph TB
   node000["XOR"]
   style node000 fill:lightpink

--- a/samples/expression_tree_mermaid/mixed_1.md
+++ b/samples/expression_tree_mermaid/mixed_1.md
@@ -1,4 +1,5 @@
 ```mermaid
+%%{ init: {"theme": "default"} }%%
 graph TB
   node000["AND"]
   style node000 fill:lightgreen

--- a/samples/expression_tree_mermaid/mixed_2.md
+++ b/samples/expression_tree_mermaid/mixed_2.md
@@ -1,4 +1,5 @@
 ```mermaid
+%%{ init: {"theme": "default"} }%%
 graph TB
   node000["AND"]
   style node000 fill:lightgreen

--- a/samples/expression_tree_mermaid/not_and_or.md
+++ b/samples/expression_tree_mermaid/not_and_or.md
@@ -1,4 +1,5 @@
 ```mermaid
+%%{ init: {"theme": "default"} }%%
 graph TB
   node000["OR"]
   style node000 fill:lightcoral

--- a/samples/expression_tree_mermaid/not_p.md
+++ b/samples/expression_tree_mermaid/not_p.md
@@ -1,4 +1,5 @@
 ```mermaid
+%%{ init: {"theme": "default"} }%%
 graph TB
   node000["NOT"]
   style node000 fill:yellow

--- a/samples/expression_tree_mermaid/or_chain.md
+++ b/samples/expression_tree_mermaid/or_chain.md
@@ -1,4 +1,5 @@
 ```mermaid
+%%{ init: {"theme": "default"} }%%
 graph TB
   node000["OR"]
   style node000 fill:lightcoral

--- a/samples/expression_tree_mermaid/or_xy.md
+++ b/samples/expression_tree_mermaid/or_xy.md
@@ -1,4 +1,5 @@
 ```mermaid
+%%{ init: {"theme": "default"} }%%
 graph TB
   node000["OR"]
   style node000 fill:lightcoral

--- a/samples/expression_tree_mermaid/single_var.md
+++ b/samples/expression_tree_mermaid/single_var.md
@@ -1,4 +1,5 @@
 ```mermaid
+%%{ init: {"theme": "default"} }%%
 graph TB
   node000["z"]
   style node000 fill:lightblue

--- a/samples/expression_tree_mermaid/xor_mn.md
+++ b/samples/expression_tree_mermaid/xor_mn.md
@@ -1,4 +1,5 @@
 ```mermaid
+%%{ init: {"theme": "default"} }%%
 graph TB
   node000["XOR"]
   style node000 fill:lightpink


### PR DESCRIPTION
This patch emits a Mermaid init directive to request the default (light) Mermaid theme which prevents host dark themes (e.g. GitHub dark mode) from making node fill/stroke colours hard to see.

- Adds an init directive at the top of Mermaid output: `%%{ init: {"theme": "default"} }%%`.
- Runs and passes existing test-suite locally (125 tests passed).

Closes: #28