### PR TITLE
Add Doxygen documentation workflow and Doxyfile

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,137 @@
+name: Generate Documentation
+
+on:
+  push:
+    branches: [ main, master, v*.*.* ]
+    tags: [ 'v*' ]
+    paths:
+      - '**.cpp'
+      - '**.h'
+      - '**.hpp'
+      - '**.md'
+      - 'Doxyfile'
+      - '.github/workflows/documentation.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Install Doxygen and Graphviz
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y doxygen graphviz
+
+      - name: Get project version
+        id: version
+        run: |
+          if git describe --tags --exact-match >/dev/null 2>&1; then
+            VERSION=$(git describe --tags --exact-match)
+          else
+            VERSION=$(git branch --show-current)
+          fi
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "Project version: $VERSION"
+
+      - name: Update Doxyfile with version
+        run: |
+          sed -i "s/PROJECT_NUMBER.*=.*/PROJECT_NUMBER = ${{ steps.version.outputs.VERSION }}/" Doxyfile || true
+
+      - name: Generate documentation
+        run: |
+          echo "Generating Doxygen documentation..."
+          doxygen Doxyfile
+          if [ ! -d "docs/html" ]; then
+            echo "Error: Documentation generation failed - no docs/html directory found"
+            exit 1
+          fi
+          if [ ! -f "docs/html/index.html" ]; then
+            echo "Error: No index.html generated"
+            exit 1
+          fi
+          echo "Documentation generated successfully"
+          ls -la docs/html/
+
+      - name: Create .nojekyll file
+        run: |
+          touch docs/html/.nojekyll
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+        with:
+          enablement: true
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: docs/html
+
+  deploy-docs:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build-docs
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+
+  deploy-branch:
+    runs-on: ubuntu-latest
+    needs: build-docs
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Install Doxygen and Graphviz
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y doxygen graphviz
+
+      - name: Get project version
+        id: version
+        run: |
+          if git describe --tags --exact-match >/dev/null 2>&1; then
+            VERSION=$(git describe --tags --exact-match)
+          else
+            VERSION=$(git branch --show-current)
+          fi
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Update Doxyfile with version
+        run: |
+          sed -i "s/PROJECT_NUMBER.*=.*/PROJECT_NUMBER = ${{ steps.version.outputs.VERSION }}/" Doxyfile || true
+
+      - name: Generate documentation
+        run: |
+          doxygen Doxyfile
+          touch docs/html/.nojekyll
+
+      - name: Deploy to documentation branch
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/html
+          publish_branch: documentation
+          force_orphan: true
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+          commit_message: 'Deploy documentation for ${{ steps.version.outputs.VERSION }}'

--- a/Doxyfile
+++ b/Doxyfile
@@ -1,0 +1,15 @@
+# Minimal Doxyfile for DagIR
+PROJECT_NAME           = "DagIR"
+PROJECT_BRIEF          = "Directed Acyclic Graph Intermediate Representation"
+PROJECT_NUMBER         = 0.0.0
+OUTPUT_DIRECTORY       = docs
+GENERATE_HTML          = YES
+HTML_OUTPUT            = html
+GENERATE_LATEX         = NO
+EXTRACT_ALL            = YES
+RECURSIVE              = YES
+INPUT                  = include src
+FILE_PATTERNS          = *.h *.hpp *.cpp *.c
+QUIET                  = NO
+WARNINGS               = YES
+GENERATE_TREEVIEW      = YES


### PR DESCRIPTION
This adds a GitHub Actions workflow to generate documentation with Doxygen and publish it to GitHub Pages. It also includes a minimal `Doxyfile` at the repo root configured to document `include/` and `src/` into `docs/html`.

Closes #32.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated documentation generation and deployment workflow that publishes to GitHub Pages on pushes to main branches and version tags

<!-- end of auto-generated comment: release notes by coderabbit.ai -->