### PR TITLE
Simpler port file

### DIFF
--- a/ports/dagir/portfile.cmake
+++ b/ports/dagir/portfile.cmake
@@ -5,27 +5,15 @@ vcpkg_from_github(
   SHA512 0450B03C282DAA9B941A56283CCC00663C8EB66C9D02BDAE05D2EA5DD60C4048A30BA4B4D3F51FE51D7A7F43132D48989140FC02D088522A2177FF779C204ED3
 )
 
-vcpkg_cmake_configure(
-  SOURCE_PATH ${SOURCE_PATH}
-  OPTIONS
-    -DDAGIR_BUILD_TESTS=OFF
-    -DDAGIR_EXAMPLES=OFF
-)
-
+vcpkg_cmake_configure(SOURCE_PATH ${SOURCE_PATH} OPTIONS -DDAGIR_BUILD_TESTS=OFF -DDAGIR_EXAMPLES=OFF)
 vcpkg_cmake_install()
-
 file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/share/dagir")
 vcpkg_cmake_config_fixup()
 
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/share/dagir")
 if(EXISTS "${SOURCE_PATH}/LICENSE")
   vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 endif()
 
-file(WRITE "${CURRENT_PACKAGES_DIR}/share/dagir/DagIRTargets.cmake"
-  "add_library(dagir::dagir INTERFACE IMPORTED)\n"
-  "set_target_properties(dagir::dagir PROPERTIES INTERFACE_INCLUDE_DIRECTORIES \"\${CMAKE_CURRENT_LIST_DIR}/../../include\")\n"
-)
-
-file(WRITE "${CURRENT_PACKAGES_DIR}/share/dagir/DagIRConfig.cmake"
-  "include(\"\${CMAKE_CURRENT_LIST_DIR}/DagIRTargets.cmake\")\n"
-)
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/dagir/DagIRTargets.cmake" "add_library(dagir::dagir INTERFACE IMPORTED)\nset_target_properties(dagir::dagir PROPERTIES INTERFACE_INCLUDE_DIRECTORIES \"\${CMAKE_CURRENT_LIST_DIR}/../../include\")\n")
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/dagir/DagIRConfig.cmake" "include(\"\${CMAKE_CURRENT_LIST_DIR}/DagIRTargets.cmake\")\n")


### PR DESCRIPTION
This pull request makes minor improvements to the `dagir` port's `portfile.cmake` by condensing multi-line CMake commands into single lines and ensuring the target directory is created before writing configuration files.

Most important changes:

**Build configuration simplification:**

* Combined multi-line `vcpkg_cmake_configure` and `file(WRITE ...)` commands into single-line statements for improved readability and maintainability.

**Packaging and directory structure:**

* Added an explicit creation of the `${CURRENT_PACKAGES_DIR}/share/dagir` directory to ensure configuration files are written to the correct location.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined build configuration and packaging workflow through internal refactoring of installation and deployment steps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->