### PR TITLE
Constrain policy object return value

### DIFF
--- a/docs/IMPLEMENTING_POLICY.md
+++ b/docs/IMPLEMENTING_POLICY.md
@@ -56,8 +56,14 @@ Notes:
 
 A `node_attributor` is any callable compatible with the `dagir::concepts::node_attributor`
 concept. Attributors are invoked with `(const View&, handle)` and are expected to
-return an attribute representation. The canonical and recommended return type is
-`dagir::ir_attr_map` (an alias for `std::unordered_map<std::string_view,std::string>`).
+return a name/value attribute representation. DagIR constrains attribute
+producers to return a forward-range of name/value elements where each element
+exposes `.first` and `.second` members convertible to `std::string_view`.
+
+The canonical and recommended return type remains `dagir::ir_attr_map` (an alias
+for `std::unordered_map<std::string_view,std::string>`), which satisfies this
+shape. For the formal concept used by the library see
+`include/dagir/concepts/name_value_range.hpp`.
 
 Example: stable-key label in a map
 
@@ -78,9 +84,15 @@ struct StableKeyAttributor {
 
 ### Implementing an `edge_attributor`
 
-`edge_attributor` callables are flexible. The `build_ir` helper accepts several
-call signatures (e.g., `(view, parent, edge_like)`, `(parent, child)`) and the
-recommended return type is `dagir::ir_attr_map`.
+`edge_attributor` callables are flexible in supported call signatures. The
+`build_ir` helper accepts variants like `(view, parent, edge_like)`,
+`(view, parent, child)`, `(parent, edge_like)`, and `(parent, child)`.
+
+Like `node_attributor`, an `edge_attributor` must return a forward-range of
+name/value elements where both `element.first` and `element.second` are
+convertible to `std::string_view`. The recommended return type is still
+`dagir::ir_attr_map`, which meets this requirement. See
+`include/dagir/concepts/name_value_range.hpp` for details on the concept.
 
 Example: simple edge attributor using `dagir::ir_attrs`
 

--- a/include/dagir/build_ir.hpp
+++ b/include/dagir/build_ir.hpp
@@ -137,7 +137,13 @@ ir_graph build_ir(const View& view, NodePolicy&& node_policy, EdgePolicy&& edge_
     // be node-attributors producing `dagir::ir_attr_map` that will populate
     // `n.attributes`. We prefer attribute-provided values; otherwise the
     // default name is used and a label from the stable key is written.
-    n.attributes = std::invoke(node_policy, view, h);
+    auto attributes = std::invoke(node_policy, view, h);
+
+    // Copy the returned attributes into the node. Note the type may not be directly compatible.
+    for (const auto& [attr_key, attr_value] : attributes) {
+      n.attributes[attr_key] = attr_value;
+    }
+
     if (!n.attributes.count(ir_attrs::k_name))
       n.attributes[ir_attrs::k_name] = std::format("node{:03}", idx);
     if (!n.attributes.count(ir_attrs::k_label)) n.attributes[ir_attrs::k_label] = std::to_string(k);

--- a/include/dagir/concepts/edge_attributor.hpp
+++ b/include/dagir/concepts/edge_attributor.hpp
@@ -11,6 +11,8 @@
 #include <type_traits>
 #include <utility>
 
+#include "dagir/concepts/name_value_range.hpp"
+
 namespace dagir::concepts {
 
 /**
@@ -23,12 +25,16 @@ namespace dagir::concepts {
  * A type models ::dagir::edge_attributor when an lvalue of @c F is invocable as:
  *  - @c f(view, parent_handle, child_handle)
  *
- * The return type is unconstrained and left to the renderer/IR builder to interpret.
+ * The callable must return a forward range of name/value pairs where both
+ * the key (`.first`) and value (`.second`) of each element are convertible
+ * to `std::string_view`. This matches the refinement applied to
+ * `dagir::concepts::node_attributor` and models attribute maps used by the
+ * renderer/IR builder.
  */
 template <class F, class View>
 concept edge_attributor = requires(const F& f, const View& v, const typename View::handle& p,
                                    const typename View::handle& c) {
-  { f(v, p, c) };
+  { f(v, p, c) } -> name_value_range;
 };
 
 }  // namespace dagir::concepts

--- a/include/dagir/concepts/name_value_range.hpp
+++ b/include/dagir/concepts/name_value_range.hpp
@@ -1,0 +1,63 @@
+/**
+ * @file name_value_range.hpp
+ * @brief Helper concepts for name/value attribute ranges.
+ *
+ * Provides `string_view_convertible`, `name_value_element`, and
+ * `name_value_range` used by node and edge attributor concepts.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#include <concepts>
+#include <ranges>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+
+namespace dagir::concepts {
+
+/**
+ * @brief Test whether a type is convertible to `std::string_view`.
+ *
+ * @tparam T candidate type
+ *
+ * This concept is used by the name/value helpers to ensure keys and values
+ * can be treated as string-like views without requiring ownership.
+ */
+template <class T>
+concept string_view_convertible = std::convertible_to<T, std::string_view>;
+
+/**
+ * @brief Checks that a range element exposes name/value members.
+ *
+ * @tparam R range-like type whose value type should expose `.first` and
+ *           `.second` members.
+ *
+ * The element type (after removing cv/ref) must provide accessible
+ * `.first` and `.second` members and both must be convertible to
+ * `std::string_view`.
+ */
+template <class R>
+concept name_value_element = requires {
+  typename std::remove_cvref_t<std::ranges::range_value_t<R>>;
+} && requires(std::remove_cvref_t<std::ranges::range_value_t<R>>& val) {
+  { val.first } -> string_view_convertible;
+  { val.second } -> string_view_convertible;
+};
+
+/**
+ * @brief A forward-range whose elements are name/value pairs.
+ *
+ * @tparam R range type
+ *
+ * This concept requires a `std::ranges::forward_range` and that each
+ * element satisfy `name_value_element` (i.e., exposes `.first` and
+ * `.second` convertible to `std::string_view`). This models attribute maps and
+ * containers used by renderers and IR builders.
+ */
+template <class R>
+concept name_value_range = std::ranges::forward_range<R> && name_value_element<R>;
+
+}  // namespace dagir::concepts

--- a/include/dagir/concepts/node_attributor.hpp
+++ b/include/dagir/concepts/node_attributor.hpp
@@ -13,10 +13,11 @@
 #pragma once
 
 #include <concepts>
-#include <type_traits>
-#include <utility>
+
+#include "dagir/concepts/name_value_range.hpp"
 
 namespace dagir::concepts {
+// Helper concepts are defined in `name_value_range.hpp`.
 
 /**
  * @brief Concept for a node attribute policy callable.
@@ -29,11 +30,15 @@ namespace dagir::concepts {
  * invocable as:
  *  - @c f(view, node_handle)
  *
- * The return type is unconstrained and left to the renderer/IR builder to interpret.
+ * The callable must return a forward range of name/value pairs where both
+ * the key (`.first`) and value (`.second`) of each element are convertible
+ * to `std::string_view`. This models name/value attribute maps used by the
+ * renderer/IR builder (for example, containers of `std::pair` or
+ * associative containers exposing element-like references).
  */
 template <class F, class View>
 concept node_attributor = requires(const F& f, const View& v, const typename View::handle& n) {
-  { f(v, n) };
+  { f(v, n) } -> name_value_range;
 };
 
 }  // namespace dagir::concepts


### PR DESCRIPTION
This pull request refines the attribute handling concepts for nodes and edges in the DagIR library, ensuring stricter and more consistent requirements for attribute producers. The key change is the introduction of the new `name_value_range` concept, which enforces that both node and edge attributors return a forward-range of name/value pairs convertible to `std::string_view`. This improves type safety and clarity for users implementing custom attributors.

**Core concept and documentation improvements:**

* Introduced the `name_value_range` concept in the new `include/dagir/concepts/name_value_range.hpp`, along with supporting concepts for checking string view convertibility and name/value element structure.
* Updated the documentation in `docs/IMPLEMENTING_POLICY.md` to clarify that both node and edge attributors must return a forward-range of name/value elements (not just a specific map type), and referenced the new concept for formal requirements. [[1]](diffhunk://#diff-3e827036ac4e13d8adb67f87e63fef2116363019a1f7884daa0d9eaf74aa9c8fL59-R66) [[2]](diffhunk://#diff-3e827036ac4e13d8adb67f87e63fef2116363019a1f7884daa0d9eaf74aa9c8fL81-R95)

**Concept enforcement in code:**

* Modified the `node_attributor` and `edge_attributor` concepts to require the return type to satisfy the `name_value_range` concept, ensuring that custom attributors are compatible with the expected attribute structure. [[1]](diffhunk://#diff-9a6a8c0083782437ca6385a7d0812e94907e1a46227f3d1a33ee9d322ee5fd5bL16-R20) [[2]](diffhunk://#diff-9a6a8c0083782437ca6385a7d0812e94907e1a46227f3d1a33ee9d322ee5fd5bL32-R41) [[3]](diffhunk://#diff-74105113a5947b5ee3ffff1acf4315615e6fecf2b3b10e636359307c81b77944R14-R15) [[4]](diffhunk://#diff-74105113a5947b5ee3ffff1acf4315615e6fecf2b3b10e636359307c81b77944L26-R37)

**IR builder compatibility:**

* Updated `build_ir` in `include/dagir/build_ir.hpp` to copy attributes from any compatible forward-range of name/value pairs into the node's attribute map, rather than assuming a specific map type. This allows greater flexibility in user-defined attributors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Documentation**
* Updated requirements for node and edge attributor implementations—functions must now return a forward-range of name/value pairs with keys and values convertible to strings.
* Expanded documentation with examples and clarified type constraints.

**Refactor**
* Strengthened type validation for attributor functions.
* Improved attribute assignment logic for enhanced compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->